### PR TITLE
allow \r\n in order to use `sendevent`

### DIFF
--- a/eventsocket/eventsocket.go
+++ b/eventsocket/eventsocket.go
@@ -324,9 +324,9 @@ func capitalize(s string) string {
 // details.
 func (h *Connection) Send(command string) (*Event, error) {
 	// Sanity check to avoid breaking the parser
-	if strings.IndexAny(command, "\r\n") > 0 {
-		return nil, errInvalidCommand
-	}
+	//if strings.IndexAny(command, "\r\n") > 0 {
+	//	return nil, errInvalidCommand
+	//}
 	fmt.Fprintf(h.conn, "%s\r\n\r\n", command)
 	var (
 		ev  *Event


### PR DESCRIPTION
Example usage:
```
event := fmt.Sprintf("sendevent SWITCH_EVENT_MESSAGE_QUERY\r\nmessage-account: %s@%s", ToUser, ToRealm)
_, err := crh.ESLConnection.Send(event)
```