### PR TITLE
timeout for response waiting

### DIFF
--- a/eventsocket/eventsocket.go
+++ b/eventsocket/eventsocket.go
@@ -468,13 +468,14 @@ func (r *Event) String() string {
 
 // Get returns an Event value, or "" if the key doesn't exist.
 func (r *Event) Get(key string) string {
-	if val, ok := r.Header[key]; !ok || val == nil {
+	val, ok := r.Header[key]
+	if !ok || val == nil {
 		return ""
 	}
-	if s, ok := r.Header[key].([]string); ok {
+	if s, ok := val.([]string); ok {
 		return strings.Join(s, ", ")
 	}
-	return r.Header[key].(string)
+	return val.(string)
 }
 
 // GetInt returns an Event value converted to int, or an error if conversion

--- a/eventsocket/eventsocket.go
+++ b/eventsocket/eventsocket.go
@@ -468,6 +468,9 @@ func (r *Event) String() string {
 
 // Get returns an Event value, or "" if the key doesn't exist.
 func (r *Event) Get(key string) string {
+	if val, ok := r.Header[key]; !ok || val == nil {
+		return ""
+	}
 	if s, ok := r.Header[key].([]string); ok {
 		return strings.Join(s, ", ")
 	}

--- a/eventsocket/eventsocket.go
+++ b/eventsocket/eventsocket.go
@@ -229,8 +229,8 @@ func (h *Connection) readOne() bool {
 		for k, v := range tmp {
 			resp.Header[capitalize(k)] = v
 		}
-		if v, _ := resp.Header["_body"]; v != "" {
-			resp.Body = v
+		if v, _ := resp.Header["_body"]; v != nil {
+			resp.Body = v.(string)
 			delete(resp.Header, "_body")
 		} else {
 			resp.Body = ""
@@ -450,7 +450,7 @@ func (h *Connection) ExecuteUUID(uuid, appName, appArg string) (*Event, error) {
 }
 
 // EventHeader represents events as a pair of key:value.
-type EventHeader map[string]string
+type EventHeader map[string]interface{}
 
 // Event represents a FreeSWITCH event.
 type Event struct {
@@ -468,13 +468,16 @@ func (r *Event) String() string {
 
 // Get returns an Event value, or "" if the key doesn't exist.
 func (r *Event) Get(key string) string {
-	return r.Header[key]
+	if s, ok := r.Header[key].([]string); ok {
+		return strings.Join(s, ", ")
+	}
+	return r.Header[key].(string)
 }
 
 // GetInt returns an Event value converted to int, or an error if conversion
 // is not possible.
 func (r *Event) GetInt(key string) (int, error) {
-	n, err := strconv.Atoi(r.Header[key])
+	n, err := strconv.Atoi(r.Header[key].(string))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
I noticed under certain network conditions another source of goroutines remaining blocked forever :
```
goroutine profile: total 240
195 @ 0x42e19a 0x43d594 0x43c1fc 0x8382f4 0x8a9bf7 0x8ba614 0x45b261
#	0x8382f3	github.com/fiorix/go-eventsocket/eventsocket.(*Connection).Send+0x283		github.com/fiorix/go-eventsocket/eventsocket/eventsocket.go:335
```

so I added a 60 second timeout on waiting for the responses from fs