### PR TITLE
Update eventsocket.go

### DIFF
--- a/eventsocket/eventsocket.go
+++ b/eventsocket/eventsocket.go
@@ -177,7 +177,7 @@ func (h *Connection) readOne() bool {
 	switch hdr.Get("Content-Type") {
 	case "command/reply":
 		reply := hdr.Get("Reply-Text")
-		if reply[:2] == "-E" {
+		if len(reply)>1 && reply[:2] == "-E" {
 			h.err <- errors.New(reply[5:])
 			return true
 		}
@@ -188,7 +188,7 @@ func (h *Connection) readOne() bool {
 		}
 		h.cmd <- resp
 	case "api/response":
-		if string(resp.Body[:2]) == "-E" {
+		if len(resp.Body)>1 && string(resp.Body[:2]) == "-E" {
 			h.err <- errors.New(string(resp.Body)[5:])
 			return true
 		}


### PR DESCRIPTION
go-eventsocket is getting crash while sending below api command 
api uuid_getvar {uuid} answered_time 

This fix will help to check the length before accessing it.